### PR TITLE
Replace deprecated onActivationCheck event listener

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -180,10 +180,11 @@ joplin.plugins.register({
       }
     });
     await joplin.workspace.onNoteSelectionChange(async () => {
+      logger.debug("Selected note has changed");
       await updateNoteInfo();
     });
 
-    // Handle the initial note selection
+    // Handle the initial note selection on desktop
     const currentNote = await joplin.workspace.selectedNote();
     if (currentNote) {
       await updateNoteInfo();


### PR DESCRIPTION
The onActivationCheck event listener is deprecated according to what VS Code is showing and in the api doc here https://joplinapp.org/api/references/plugin_api/classes/joplinviewseditors.html#onactivationcheck

This PR replaces it with an alternative implementation. I have tested this on both desktop and mobile and it works fine, correctly showing the correct encrypted / decrypted status when starting the app (on desktop), when switching between encrypted / decrypted notes, and when toggling encryption for a note