### PR TITLE
Fix the latest note contents not being encrypted / decrypted, if using undo / redo before doing so

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -168,19 +168,19 @@ async function toggleLock() {
   logger.debug("IsLocked:", isLocked);
 
   if(!isLocked) {
-    await encryptNote();
+    await encryptNote(note.id);
   } else {
-    await decryptNote();
+    await decryptNote(note.id);
   }
 }
 
 /**
  * Encrypt the active note using a password and AES encryption.
  */
-export async function encryptNote() {
+export async function encryptNote(noteId: string) {
   logger.debug("EncryptNote invoked");
   
-  const note = await joplin.workspace.selectedNote();
+  const note = await joplin.data.get(['notes', noteId], { fields: ['*'] });
   const isLocked = await isCodeblockPresent(note.body, PLUGIN_ID!);
 
   if (isLocked) {
@@ -218,10 +218,10 @@ ${encryptedData}
 /**
  * Decrypt the active note and remove encryption.
  */
-export async function decryptNote() {
+export async function decryptNote(noteId: string) {
   logger.debug("DecryptNote invoked");
   
-  const note = await joplin.workspace.selectedNote();
+  const note = await joplin.data.get(['notes', noteId], { fields: ['*'] });
   const isLocked = await isCodeblockPresent(note.body, PLUGIN_ID!);
 
   if (!isLocked) {


### PR DESCRIPTION
On the mobile app, if you have a note in edit mode and make some changes, if you then use the undo / redo buttons in the header and then encrypt / decrypt the note without leaving the note or toggle between view / edit mode, the toggle lock will not use the latest contents for the encrypted / decrypted result. Instead it will use the contents without any changes made via undo / redo. This is because the joplin.workspace.selectedNote() command does not necessarily return the most up to date note content.

This PR remedies the issues by invoking the GET note api immediately before encryption / decryption, using only the note id from joplin.workspace.selectedNote() to identify the note which needs to be refreshed. I've tested this on both Android and Windows to verify the behaviour works as expected.